### PR TITLE
Inclusion of a new optional parameter which determines the number  consumer threads

### DIFF
--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQConsumerThread.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQConsumerThread.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package io.siddhi.extension.io.rabbitmq.source;
+
+import com.rabbitmq.client.Channel;
+import io.siddhi.core.stream.input.source.SourceEventListener;
+import org.apache.log4j.Logger;
+
+import java.util.concurrent.BlockingQueue;
+
+/**
+ * RabbitMQ consumer thread implementation.
+ */
+public class RabbitMQConsumerThread implements Runnable {
+
+    private static final Logger log = Logger.getLogger(RabbitMQConsumerThread.class);
+    private final BlockingQueue<RabbitMQMessage> blockingQueue;
+    private SourceEventListener sourceEventListener;
+    private boolean autoAck;
+    private Channel channel;
+    private String listenerUri;
+    private String exchangeName;
+
+    RabbitMQConsumerThread(BlockingQueue<RabbitMQMessage> blockingQueue, Channel channel,
+                           SourceEventListener sourceEventListener, boolean autoAck, String listenerUri,
+                           String exchangeName) {
+        this.blockingQueue = blockingQueue;
+        this.channel = channel;
+        this.sourceEventListener = sourceEventListener;
+        this.autoAck = autoAck;
+        this.listenerUri = listenerUri;
+        this.exchangeName = exchangeName;
+    }
+
+    @Override
+    public void run() {
+        while (true) {
+            try {
+                RabbitMQMessage rabbitMQMessage = blockingQueue.take();
+                sourceEventListener.onEvent(rabbitMQMessage.getBody(), null);
+                if (!autoAck) {
+                    channel.basicAck(rabbitMQMessage.getEnvelope().getDeliveryTag(), false);
+                }
+            } catch (InterruptedException e) {
+                log.error("Error when reading message from blocking queue at RabbitMQ receiver " +
+                        listenerUri + " and exchange name " + exchangeName, e);
+            } catch (Exception e) {
+                log.error("Error in processing the message received from RabbitMQ broker in "
+                        + listenerUri + " and exchange name " + exchangeName, e);
+            }
+        }
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQMessage.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQMessage.java
@@ -1,0 +1,52 @@
+/*
+ *  Copyright (c) 2019 WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing,
+ *  software distributed under the License is distributed on an
+ *  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ *  KIND, either express or implied.  See the License for the
+ *  specific language governing permissions and limitations
+ *  under the License.
+ *
+ */
+
+package io.siddhi.extension.io.rabbitmq.source;
+
+import com.rabbitmq.client.Envelope;
+
+/**
+ * RabbitMQ message wrapper class.
+ */
+public class RabbitMQMessage {
+
+    public RabbitMQMessage(byte[] body, Envelope envelope) {
+        this.body = body;
+        this.envelope = envelope;
+    }
+
+    private byte[] body;
+    private Envelope envelope;
+
+    public byte[] getBody() {
+        return body;
+    }
+
+    public void setBody(byte[] body) {
+        this.body = body;
+    }
+
+    public void setEnvelope(Envelope envelope) {
+        this.envelope = envelope;
+    }
+
+    public Envelope getEnvelope() {
+        return envelope;
+    }
+}

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQSource.java
@@ -50,6 +50,7 @@ import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.CertificateException;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeoutException;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
@@ -230,6 +231,8 @@ public class RabbitMQSource extends Source {
     private String siddhiAppName;
     private boolean autoAck;
     private int consumerThreadPoolSize;
+    private ExecutorService executorService;
+
 
     @Override
     public StateFactory init(SourceEventListener sourceEventListener, OptionHolder optionHolder, String[] strings,
@@ -285,6 +288,7 @@ public class RabbitMQSource extends Source {
 
         String headers = optionHolder.validateAndGetStaticValue(RabbitMQConstants.RABBITMQ_HEADERS,
                 RabbitMQConstants.NULL);
+        this.executorService = siddhiAppContext.getExecutorService();
 
         if (headers != null) {
             try {
@@ -365,7 +369,7 @@ public class RabbitMQSource extends Source {
             rabbitMQConsumer = new RabbitMQConsumer();
             rabbitMQConsumer.consume(listenerUri,  connection, exchangeName, exchangeType, exchangeDurable,
                     exchangeAutoDelete, queueName, queueExclusive, queueDurable, queueAutodelete, routingKey, map,
-                    sourceEventListener, connectionCallback, autoAck, consumerThreadPoolSize);
+                    sourceEventListener, connectionCallback, autoAck, consumerThreadPoolSize, executorService);
         } catch (IOException e) {
             throw new ConnectionUnavailableException(
                     "Failed to connect with the Rabbitmq server. Check the " +

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQSource.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/source/RabbitMQSource.java
@@ -187,7 +187,7 @@ import javax.net.ssl.TrustManagerFactory;
                         name = "consumer.threadpool.size",
                         description = "The number of consumer threads to be registered",
                         type = {DataType.INT},
-                        optional = true, defaultValue = "10")
+                        optional = true, defaultValue = "1")
         },
         examples = {
                 @Example(

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
@@ -77,8 +77,10 @@ public class RabbitMQConstants {
     public static final String RABBITMQ_QUEUE_AUTO_DELETE = "queue.autodelete.enabled";
     public static final String RABBITMQ_QUEUE_EXCLUSIVE = "queue.exclusive.enabled";
     public static final String RABBITMQ_AUTO_ACK = "auto.ack";
+    public static final String RABBITMQ_CONSUMERS_NUMBER = "consumers.number";
     public static final String DEFAULT_QUEUE_DURABLE = "false";
     public static final String DEFAULT_QUEUE_AUTO_DELETE = "false";
     public static final String DEFAULT_QUEUE_EXCLUSIVE = "false";
     public static final String DEFAULT_AUTO_ACK = "true";
+    public static final String DEFAULT_CONSUMERS_NUMBER = "1";
 }

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
@@ -77,10 +77,10 @@ public class RabbitMQConstants {
     public static final String RABBITMQ_QUEUE_AUTO_DELETE = "queue.autodelete.enabled";
     public static final String RABBITMQ_QUEUE_EXCLUSIVE = "queue.exclusive.enabled";
     public static final String RABBITMQ_AUTO_ACK = "auto.ack";
-    public static final String RABBITMQ_CONSUMERS_NUMBER = "consumers.number";
+    public static final String RABBITMQ_CONSUMER_THREADPOOL_SIZE = "consumer.threadpool.size";
     public static final String DEFAULT_QUEUE_DURABLE = "false";
     public static final String DEFAULT_QUEUE_AUTO_DELETE = "false";
     public static final String DEFAULT_QUEUE_EXCLUSIVE = "false";
     public static final String DEFAULT_AUTO_ACK = "true";
-    public static final String DEFAULT_CONSUMERS_NUMBER = "1";
+    public static final String DEFAULT_CONSUMER_THREADPOOL_SIZE = "10";
 }

--- a/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
+++ b/component/src/main/java/io/siddhi/extension/io/rabbitmq/util/RabbitMQConstants.java
@@ -82,5 +82,5 @@ public class RabbitMQConstants {
     public static final String DEFAULT_QUEUE_AUTO_DELETE = "false";
     public static final String DEFAULT_QUEUE_EXCLUSIVE = "false";
     public static final String DEFAULT_AUTO_ACK = "true";
-    public static final String DEFAULT_CONSUMER_THREADPOOL_SIZE = "10";
+    public static final String DEFAULT_CONSUMER_THREADPOOL_SIZE = "1";
 }

--- a/findbugs-exclude.xml
+++ b/findbugs-exclude.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+  ~
+  ~ WSO2 Inc. licenses this file to you under the Apache License,
+  ~ Version 2.0 (the "License"); you may not use this file except
+  ~ in compliance with the License.
+  ~ You may obtain a copy of the License at
+  ~
+  ~   http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing,
+  ~ software distributed under the License is distributed on an
+  ~ "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  ~ KIND, either express or implied.  See the License for the
+  ~ specific language governing permissions and limitations
+  ~ under the License.
+  -->
+
+<FindBugsFilter>
+    <Match>
+        <Class name="io.siddhi.extension.io.rabbitmq.source.RabbitMQMessage"/>
+        <Bug pattern="EI_EXPOSE_REP, EI_EXPOSE_REP2"/>
+    </Match>
+    <Match>
+        <Class name="io.siddhi.extension.io.rabbitmq.source.RabbitMQConsumer"/>
+        <Bug pattern="RV_RETURN_VALUE_IGNORED_BAD_PRACTICE"/>
+    </Match>
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,7 @@
         <maven.failsafe.plugin.version>2.19.1</maven.failsafe.plugin.version>
         <docker.maven.plugin.version>0.15.9</docker.maven.plugin.version>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+        <mavan.findbugsplugin.exclude.file>findbugs-exclude.xml</mavan.findbugsplugin.exclude.file>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
## Purpose
Trying to consume messages from a queue, and also process them (for example, insert data from the message into a database), the  number of messages consumed for second decreases considerably.
## Goals
With the new parameter (consumers.number), we can increase the number of consumers running concurrently, which will increase the system throughput.

